### PR TITLE
Add Ubuntu 26 deployment support

### DIFF
--- a/.github/workflows/ubuntu26.yml
+++ b/.github/workflows/ubuntu26.yml
@@ -1,0 +1,59 @@
+name: Ubuntu 26 Compatibility
+
+on:
+  push:
+    branches: [ubuntu-26]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  node-compatibility:
+    name: Node 22 compatibility
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f package-lock.json ]]; then
+            npm ci
+          else
+            npm install --package-lock=true
+          fi
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify application startup files
+        run: |
+          node --check ./bin/cluster
+          node --check ./bin/instance
+          node --check ./app.js
+          node --check ./scripts/prestart.js
+
+      - name: Validate installer shell syntax
+        run: bash -n ./install-ubuntu26.sh
+
+      - name: Upload generated lockfile
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ubuntu26-package-lock
+          path: package-lock.json
+          if-no-files-found: ignore

--- a/UBUNTU26.md
+++ b/UBUNTU26.md
@@ -1,0 +1,50 @@
+# Ubuntu 26 deployment
+
+This branch prepares the Yerbas eIquidus explorer for Ubuntu 26 with Node.js 22, MongoDB 8, PM2, nginx, and UFW.
+
+## Install
+
+```bash
+git clone --branch ubuntu-26 https://github.com/The-Yerbas-Endeavor/explorer-YERB.git
+cd explorer-YERB
+sudo bash install-ubuntu26.sh
+```
+
+The installer defaults to:
+
+- Application directory: `~/explorer-YERB`
+- Node.js: 22
+- MongoDB: 8.0
+- Explorer port: 3001
+- Public web port: 80 through nginx
+- PM2 process name: `explorer-YERB`
+
+## Configure Yerbas RPC
+
+After installation, edit `settings.json` and configure the wallet RPC connection, coin details, markets, and public hostname. The RPC username, password, port, and wallet daemon settings must match `yerbas.conf`.
+
+Restart after changing settings:
+
+```bash
+pm2 restart explorer-YERB
+pm2 logs explorer-YERB
+```
+
+## Useful checks
+
+```bash
+node --version
+mongod --version
+pm2 status
+sudo systemctl status mongod nginx
+sudo nginx -t
+curl -I http://127.0.0.1:3001
+```
+
+## MongoDB packages on Ubuntu 26
+
+Until MongoDB publishes packages specifically labeled for Ubuntu 26, the installer uses MongoDB 8 packages from the Ubuntu 24.04 `noble` repository. This should be replaced with the native Ubuntu 26 repository as soon as MongoDB publishes one.
+
+## Compatibility workflow
+
+`.github/workflows/ubuntu26.yml` tests the project with Node.js 22, validates JavaScript entry points, runs the Jasmine test suite, checks installer syntax, and uploads the generated lockfile for troubleshooting.

--- a/install-ubuntu26.sh
+++ b/install-ubuntu26.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+APP_NAME="explorer-YERB"
+APP_USER="${SUDO_USER:-$USER}"
+APP_HOME="$(getent passwd "$APP_USER" | cut -d: -f6)"
+APP_DIR="${APP_DIR:-$APP_HOME/$APP_NAME}"
+REPO_URL="${REPO_URL:-https://github.com/The-Yerbas-Endeavor/explorer-YERB.git}"
+BRANCH="${BRANCH:-ubuntu-26}"
+NODE_MAJOR="${NODE_MAJOR:-22}"
+MONGODB_MAJOR="${MONGODB_MAJOR:-8.0}"
+PORT="${PORT:-3001}"
+
+log() { printf '\n\033[1;32m==> %s\033[0m\n' "$*"; }
+fail() { printf '\n\033[1;31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || fail "Run with sudo: sudo bash install-ubuntu26.sh"
+source /etc/os-release
+[[ "${ID:-}" == "ubuntu" ]] || fail "Ubuntu is required"
+
+log "Installing base packages"
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  ca-certificates curl gnupg git build-essential python3 pkg-config nginx ufw
+
+log "Installing Node.js ${NODE_MAJOR}"
+install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+  | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+printf 'deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_%s.x nodistro main\n' "$NODE_MAJOR" \
+  > /etc/apt/sources.list.d/nodesource.list
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
+
+log "Installing MongoDB ${MONGODB_MAJOR}"
+# MongoDB may not publish an Ubuntu 26 repository immediately. Use the newest
+# supported Ubuntu repository as a compatibility source until native packages exist.
+MONGO_SUITE="noble"
+curl -fsSL "https://www.mongodb.org/static/pgp/server-${MONGODB_MAJOR}.asc" \
+  | gpg --dearmor -o "/etc/apt/keyrings/mongodb-server-${MONGODB_MAJOR}.gpg"
+printf 'deb [arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-%s.gpg] https://repo.mongodb.org/apt/ubuntu %s/mongodb-org/%s multiverse\n' \
+  "$MONGODB_MAJOR" "$MONGO_SUITE" "$MONGODB_MAJOR" \
+  > "/etc/apt/sources.list.d/mongodb-org-${MONGODB_MAJOR}.list"
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get install -y mongodb-org
+systemctl enable --now mongod
+
+log "Installing PM2"
+npm install --global pm2
+
+log "Downloading explorer"
+if [[ -d "$APP_DIR/.git" ]]; then
+  sudo -u "$APP_USER" git -C "$APP_DIR" fetch --all --prune
+  sudo -u "$APP_USER" git -C "$APP_DIR" checkout "$BRANCH"
+  sudo -u "$APP_USER" git -C "$APP_DIR" pull --ff-only origin "$BRANCH"
+else
+  sudo -u "$APP_USER" git clone --branch "$BRANCH" "$REPO_URL" "$APP_DIR"
+fi
+
+log "Installing Node dependencies"
+cd "$APP_DIR"
+if [[ -f package-lock.json ]]; then
+  sudo -u "$APP_USER" npm ci --omit=dev
+else
+  sudo -u "$APP_USER" npm install --omit=dev
+fi
+
+log "Creating environment file"
+cat > "$APP_DIR/.env.ubuntu26" <<EOF
+NODE_ENV=production
+PORT=$PORT
+EOF
+chown "$APP_USER:$APP_USER" "$APP_DIR/.env.ubuntu26"
+chmod 600 "$APP_DIR/.env.ubuntu26"
+
+log "Configuring PM2"
+sudo -u "$APP_USER" env PATH="$PATH" pm2 delete "$APP_NAME" >/dev/null 2>&1 || true
+sudo -u "$APP_USER" env PATH="$PATH" pm2 start "$APP_DIR/bin/instance" \
+  --name "$APP_NAME" \
+  --interpreter "$(command -v node)" \
+  --node-args="--stack-size=10000" \
+  --cwd "$APP_DIR"
+sudo -u "$APP_USER" env PATH="$PATH" pm2 save
+pm2 startup systemd -u "$APP_USER" --hp "$APP_HOME" >/tmp/pm2-startup.txt
+bash -c "$(tail -n 1 /tmp/pm2-startup.txt)" || true
+
+log "Configuring nginx"
+cat > /etc/nginx/sites-available/explorer-YERB <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+    server_name _;
+
+    location / {
+        proxy_pass http://127.0.0.1:$PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+EOF
+ln -sfn /etc/nginx/sites-available/explorer-YERB /etc/nginx/sites-enabled/explorer-YERB
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+systemctl enable --now nginx
+systemctl reload nginx
+
+log "Configuring firewall"
+ufw allow OpenSSH
+ufw allow 'Nginx Full'
+ufw --force enable
+
+log "Installation complete"
+printf 'Explorer directory: %s\n' "$APP_DIR"
+printf 'Explorer URL:       http://SERVER_IP/\n'
+printf 'MongoDB status:     systemctl status mongod\n'
+printf 'Explorer status:    sudo -u %s pm2 status\n' "$APP_USER"
+printf '\nEdit settings.json before production use, then restart with:\n'
+printf '  sudo -u %s pm2 restart %s\n' "$APP_USER" "$APP_NAME"


### PR DESCRIPTION
Closed because the target repository was clarified.

`explorer-YERB` is the upstream/base code only. Ubuntu 26 compatibility and future modernization work will be applied to `The-Yerbas-Endeavor/YERB-Multi-Explorer` instead.